### PR TITLE
🐛 Fixed null pointer referencing in template

### DIFF
--- a/src/main/resources/templates/event/new.html
+++ b/src/main/resources/templates/event/new.html
@@ -25,7 +25,7 @@
 		<div>
 			<label for="host" th:text="#{field.host}"></label>
 			<select name="host" th:value="${host}">
-				<option th:each="user : ${users}" th:value="${user.id}" th:text="${user.name}" th:selected="${event.host.id} == ${user.id}"></option>
+				<option th:each="user : ${users}" th:value="${user.id}" th:text="${user.name}" th:selected="${host} == ${user.id}"></option>
 			</select>
 			<button type="submit" th:text="#{events.new}"></button>
 	</form>


### PR DESCRIPTION
The potential host ID is not referenced by the event, where it's no longer available, but by the `host` variable, where it's passed to the view.